### PR TITLE
replace deprecated CSS2 system colors

### DIFF
--- a/dist/toolwindow.css
+++ b/dist/toolwindow.css
@@ -1,12 +1,14 @@
 /*
 Use this as a template for toolwindow styling
 - this styling is similar to that found on Windows 10
+Deprecated CSS2 system colors are replaced based on the samples shown here:
+https://adrianroselli.com/2021/02/whcm-and-system-colors.html#CSS2
  */
 .dialog {
 	font-family: Verdana, sans-serif;
 	font-size: 12px;
 	font-weight: 400;
-	color: WindowText;
+	color: #000000; 				/* replace deprecated CSS2 system color WindowText */
 	background: Window;
 	margin: 0;
 	position: absolute;
@@ -16,8 +18,8 @@ Use this as a template for toolwindow styling
 	box-shadow: 2px 2px 5px 2px rgba(0,0,0,0.5);
 }
 .dialog .titlebar {
-	background: ActiveCaption;
-    color: CaptionText;
+	background: #99b4d1; 			/* replace deprecated CSS2 system color ActiveCaption */
+    color: #000000; 				/* replace deprecated CSS2 system color CaptionText */
 	height: 32px;
 	line-height: 32px;
 	vertical-align: middle;
@@ -50,7 +52,7 @@ Use this as a template for toolwindow styling
 }
 
 .dialog .button-bar {
-	background: ThreeDFace;
+	background: #f0f0f0;				/* replace deprecated CSS2 system color ThreeDFace */
 	position: absolute;
 	bottom: 0;
     width: 100%;
@@ -58,7 +60,7 @@ Use this as a template for toolwindow styling
 	user-select: none; /* no select/copy to clipboard */
 }
 .dialog button.close {
-    color: CaptionText;
+    color: #000000; 					/* replace deprecated CSS2 system color CaptionText */
     background: transparent;
 	position: absolute;
 	right: 0;
@@ -81,9 +83,9 @@ Use this as a template for toolwindow styling
 	cursor: pointer;
 }
 .dialog .button-bar button {
-    color: ButtonText;
-	background: ButtonFace;
-	border: 1px solid ThreeDShadow;
+    color: #000000; 					/* replace deprecated CSS2 system color ButtonText */
+	background: #e9e9ed; 				/* replace deprecated CSS2 system color ButtonFace */
+	border: 1px solid #f0f0f0; 			/* replace deprecated CSS2 system color ThreeDShadow*/
 	height: 32px;
 	min-width: 64px;
 	font-size: 1.1em;
@@ -94,8 +96,8 @@ Use this as a template for toolwindow styling
 
 .dialog .button-bar button:hover {
 	border: 1px solid Highlight;
-	color: CaptionText;
-	background: InactiveCaption;
+	color: #000000; 					/* replace deprecated CSS2 system color CaptionText */
+	background: #bfcddb; 				/* replace deprecated CSS2 system color InactiveCaption */
 	transition: 1s;
 }
 
@@ -104,7 +106,7 @@ Use this as a template for toolwindow styling
 	height: 0;
 	border-left: 5px solid transparent;
 	border-right: 5px solid transparent;
-	border-bottom: 5px solid ButtonShadow;
+	border-bottom: 5px solid #a0a0a0;	/* replace deprecated CSS2 system color ButtonShadow */
 	position: absolute;
 }
 


### PR DESCRIPTION
The current versions of Chrome and Edge do not show the deprecated CSS2 system colors anymore. Firefox still works.
I used a color picker on page https://adrianroselli.com/2021/02/whcm-and-system-colors.html#CSS2 to get the color codes seen before.